### PR TITLE
Set an upper bound on the frame time

### DIFF
--- a/src/win/main.cpp
+++ b/src/win/main.cpp
@@ -78,6 +78,9 @@ int main(int argc, char **argv) {
         } else {
             int time = osGetTime();
             deltaTime = (time - lastTime) / 1000.0f;
+            if (deltaTime > 0.1f) {
+                deltaTime = 0.1f;
+            }
             lastTime = time;
 
             glClear(GL_COLOR_BUFFER_BIT);


### PR DESCRIPTION
To prevent long jumps in case of a freeze (possibly better to do this in the platform-independent frame function though).